### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
@@ -84,8 +84,7 @@ protected:
   CriterionPointer          m_SubdivisionCriterion;
 
 private:
-  ConditionalSubdivisionQuadEdgeMeshFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & );                // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConditionalSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -83,8 +83,7 @@ protected:
   unsigned int                    m_ResolutionLevels;
 
 private:
-  IterativeTriangleCellSubdivisionQuadEdgeMeshFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & );                // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -89,8 +89,7 @@ protected:
   virtual void AddNewCellPoints( InputCellType * cell ) ITK_OVERRIDE;
 
 private:
-  LinearTriangleCellSubdivisionQuadEdgeMeshFilter( const Self & );
-  void operator=( const Self & );
+  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -87,8 +87,7 @@ protected:
   virtual void AddNewEdgePoints( InputQEType * edge ) ITK_OVERRIDE;
 
 private:
-  LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter( const Self & );//purposely not implement
-  void operator=( const Self & );//purposely not implement
+  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -116,8 +116,7 @@ protected:
   InputPointType SmoothingPoint( const InputPointType & ipt, const InputPointsContainer * points );
 
 private:
-  LoopTriangleCellSubdivisionQuadEdgeMeshFilter(const Self &);
-  void operator=(const Self &);
+  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -91,8 +91,7 @@ protected:
   virtual void AverageOriginOfEdge( InputQEType * edge, const InputPointsContainer * points );
 
 private:
-  LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter( const Self & );//purposely not implement
-  void operator=( const Self & );//purposely not implement
+  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -90,8 +90,7 @@ protected:
   virtual void AddNewCellPoints( InputCellType *cell ) ITK_OVERRIDE;
 
 private:
-  ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter( const Self & );
-  void operator=( const Self & );
+  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -87,8 +87,7 @@ protected:
   virtual void AddNewEdgePoints( InputQEType * edge ) ITK_OVERRIDE;
 
 private:
-  ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter( const Self & );//purposely not implement
-  void operator=( const Self & );//purposely not implement
+  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -94,8 +94,7 @@ protected:
   virtual void GenerateOutputCells() ITK_OVERRIDE;
 
 private:
-  SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter( const Self & );
-  void operator=( const Self & );
+  ITK_DISALLOW_COPY_AND_ASSIGN(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSubdivisionQuadEdgeMeshFilter.h
@@ -107,8 +107,7 @@ protected:
   EdgePointIdentifierContainerPointer m_EdgesPointIdentifier;
 
 private:
-  SubdivisionQuadEdgeMeshFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & );                // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -118,8 +118,7 @@ protected:
   bool                            m_Uniform;
 
 private:
-  TriangleCellSubdivisionQuadEdgeMeshFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & ); // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -99,8 +99,7 @@ protected:
   SubdivisionCellContainer    m_EdgesToBeSubdivided;
 
 private:
-  TriangleEdgeCellSubdivisionQuadEdgeMeshFilter( const Self & ); // purposely not implemented
-  void operator=( const Self & );                // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses c++11's rigorous function deletion on compilers that support it.