### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
@@ -36,6 +36,8 @@ class ConditionalSubdivisionQuadEdgeMeshFilter:
   public QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, typename TSubdivisionFilter::OutputMeshType >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConditionalSubdivisionQuadEdgeMeshFilter);
+
   using Self = ConditionalSubdivisionQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, typename TSubdivisionFilter::OutputMeshType>;
   using Pointer = SmartPointer< Self >;
@@ -82,9 +84,6 @@ protected:
   SubdivisionFilterPointer  m_SubdivisionFilter;
   SubdivisionCellContainer  m_CellsToBeSubdivided;
   CriterionPointer          m_SubdivisionCriterion;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConditionalSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -35,6 +35,8 @@ class IterativeTriangleCellSubdivisionQuadEdgeMeshFilter:
   public QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, typename TCellSubdivisionFilter::OutputMeshType >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = IterativeTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, typename TCellSubdivisionFilter::OutputMeshType>;
   using Pointer = SmartPointer< Self >;
@@ -81,9 +83,6 @@ protected:
   CellSubdivisionFilterPointer    m_CellSubdivisionFilter;
   SubdivisionCellContainer        m_CellsToBeSubdivided;
   unsigned int                    m_ResolutionLevels;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -37,6 +37,8 @@ class LinearTriangleCellSubdivisionQuadEdgeMeshFilter:
   public TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = LinearTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -87,9 +89,6 @@ protected:
   ~LinearTriangleCellSubdivisionQuadEdgeMeshFilter() override {}
 
   void AddNewCellPoints( InputCellType * cell ) override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,6 +34,8 @@ class LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter:
   public TriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -85,9 +87,6 @@ protected:
   ~LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter() override {}
 
   void AddNewEdgePoints( InputQEType * edge ) override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -55,6 +55,8 @@ class LoopTriangleCellSubdivisionQuadEdgeMeshFilter:
   public TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = LoopTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -114,9 +116,6 @@ protected:
   void AddNewCellPoints( InputCellType *cell ) override;
 
   InputPointType SmoothingPoint( const InputPointType & ipt, const InputPointsContainer * points );
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,6 +34,8 @@ class LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter:
   public TriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -89,9 +91,6 @@ protected:
   void CopyInputMeshToOutputMeshPoints() override;
 
   virtual void AverageOriginOfEdge( InputQEType * edge, const InputPointsContainer * points );
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -39,6 +39,8 @@ class ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter:
   public TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -88,9 +90,6 @@ protected:
   ~ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter() override {}
 
   void AddNewCellPoints( InputCellType *cell ) override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,6 +34,8 @@ class ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter:
   public TriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -85,9 +87,6 @@ protected:
   ~ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter() override {}
 
   void AddNewEdgePoints( InputQEType * edge ) override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,6 +34,8 @@ class SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter:
   public TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -92,9 +94,6 @@ protected:
 
   void AddNewCellPoints( InputCellType *cell ) override;
   void GenerateOutputCells() override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 }
 

--- a/include/itkSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSubdivisionQuadEdgeMeshFilter.h
@@ -41,6 +41,8 @@ class SubdivisionQuadEdgeMeshFilter:
   public QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SubdivisionQuadEdgeMeshFilter);
+
   using Self = SubdivisionQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -105,9 +107,6 @@ protected:
   void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   EdgePointIdentifierContainerPointer m_EdgesPointIdentifier;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -40,6 +40,8 @@ class TriangleCellSubdivisionQuadEdgeMeshFilter:
   public SubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = TriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = SubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -116,9 +118,6 @@ protected:
 
   SubdivisionCellContainer        m_CellsToBeSubdivided;
   bool                            m_Uniform;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleCellSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 

--- a/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,6 +34,8 @@ class TriangleEdgeCellSubdivisionQuadEdgeMeshFilter:
   public TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+
   using Self = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
   using Pointer = SmartPointer< Self >;
@@ -97,9 +99,6 @@ protected:
   void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   SubdivisionCellContainer    m_EdgesToBeSubdivided;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.