### PR TITLE
COMP: Prefer C++11 math over vcl_*

### DIFF
--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -208,7 +208,7 @@ LoopTriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
           }
         else
           {
-          InputCoordType var  = 0.375 + 0.25 * vcl_cos(2.0 * vnl_math::pi / nn);
+          InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * vnl_math::pi / nn);
           InputCoordType beta = ( 0.625 - var * var ) / nn;
           for ( unsigned int kk = 0; kk < InputMeshType::PointDimension; ++kk )
             {
@@ -271,7 +271,7 @@ LoopTriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
     }
   else
     {
-    InputCoordType var  = 0.375 + 0.25 * vcl_cos(2.0 * vnl_math::pi / nn);
+    InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * vnl_math::pi / nn);
     InputCoordType beta = ( 0.625 - var * var ) / nn;
     for ( unsigned int kk = 0; kk < InputMeshType::PointDimension; ++kk )
       {

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -189,7 +189,7 @@ LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
     }
   else
     {
-    InputCoordType var  = 0.375 + 0.25 * vcl_cos(2.0 * vnl_math::pi / nn);
+    InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * vnl_math::pi / nn);
     InputCoordType beta = ( 0.625 - var * var ) / nn;
     for ( unsigned int kk = 0; kk < InputMeshType::PointDimension; ++kk )
       {


### PR DESCRIPTION
The vcl_ functions are aliases to the C++11 variants,
so just use C++11 directly.