### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,7 @@
 #define itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
 #include "itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include <set>
 
 namespace itk
@@ -208,7 +208,7 @@ LoopTriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
           }
         else
           {
-          InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * vnl_math::pi / nn);
+          InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * itk::Math::pi / nn);
           InputCoordType beta = ( 0.625 - var * var ) / nn;
           for ( unsigned int kk = 0; kk < InputMeshType::PointDimension; ++kk )
             {
@@ -271,7 +271,7 @@ LoopTriangleCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
     }
   else
     {
-    InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * vnl_math::pi / nn);
+    InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * itk::Math::pi / nn);
     InputCoordType beta = ( 0.625 - var * var ) / nn;
     for ( unsigned int kk = 0; kk < InputMeshType::PointDimension; ++kk )
       {

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,7 @@
 #define itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 
 #include "itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include <algorithm>
 
 namespace itk
@@ -189,7 +189,7 @@ LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
     }
   else
     {
-    InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * vnl_math::pi / nn);
+    InputCoordType var  = 0.375 + 0.25 * std::cos(2.0 * itk::Math::pi / nn);
     InputCoordType beta = ( 0.625 - var * var ) / nn;
     for ( unsigned int kk = 0; kk < InputMeshType::PointDimension; ++kk )
       {


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace