### PR TITLE
ENH: Add a CMake minimum required version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,3 @@
+cmake_minimum_required(VERSION 3.10.2)
 project( itkSubdivisionQuadEdgeMeshFilter )
 itk_module_impl()


### PR DESCRIPTION
Add a CMake minimum required version: match the version with the version
currently required by ITK master.