### PR TITLE
STYLE: Conform to ITK remote module naming guidelines.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
-project( itkSubdivisionQuadEdgeMeshFilter )
+project(SubdivisionQuadEdgeMeshFilter)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)


### PR DESCRIPTION
Conform to ITK remote module naming guidelines: the module's name should
**not** contain the `ITK` prefix.