### PR TITLE
ENH: Enable building module outside ITK.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,9 @@
 project( itkSubdivisionQuadEdgeMeshFilter )
-itk_module_impl()
+
+if(NOT ITK_SOURCE_DIR)
+  find_package(ITK REQUIRED)
+  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
+  include(ITKModuleExternal)
+else()
+  itk_module_impl()
+endif()


### PR DESCRIPTION
Modify the `CMakeLists.txt` file to enable building the module outside
ITK.