### PR TITLE
BUG: Pass CellData In Triangle Cell Subdivision

### DIFF
--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -21,6 +21,7 @@
 
 #include "itkQuadEdgeMeshToQuadEdgeMeshFilter.h"
 #include "itkConceptChecking.h"
+#include <vector>
 
 namespace itk
 {
@@ -44,6 +45,7 @@ public:
 
   using CellSubdivisionFilterType = TCellSubdivisionFilter;
   using CellSubdivisionFilterPointer = typename CellSubdivisionFilterType::Pointer;
+  using CellSubdivisionFilterPointerVector = typename std::vector<CellSubdivisionFilterPointer>;
 
   using InputMeshType = TInputMesh;
   using InputMeshPointer = typename InputMeshType::Pointer;
@@ -68,10 +70,10 @@ public:
 
   itkSetMacro(ResolutionLevels, unsigned int);
   itkGetConstMacro(ResolutionLevels, unsigned int);
+  void
+  SetCellsToBeSubdivided(const SubdivisionCellContainer &);
   itkGetConstReferenceMacro(CellsToBeSubdivided, SubdivisionCellContainer);
 
-  void
-  SetCellsToBeSubdivided(const SubdivisionCellContainer & cellIdList);
   void
   AddSubdividedCellId(OutputCellIdentifier cellId);
 
@@ -86,9 +88,9 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  CellSubdivisionFilterPointer m_CellSubdivisionFilter;
-  SubdivisionCellContainer     m_CellsToBeSubdivided;
-  unsigned int                 m_ResolutionLevels;
+  CellSubdivisionFilterPointerVector m_CellSubdivisionFilterVector;
+  SubdivisionCellContainer           m_CellsToBeSubdivided;
+  unsigned int                       m_ResolutionLevels;
 };
 } // end namespace itk
 

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -91,7 +91,7 @@ SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::G
   // 2. Get cells container from input
   const InputCellsContainer * cells = input->GetCells();
 
-  // 3. Clearn cells to be subdivided.
+  // 3. Clear cells to be subdivided.
   this->m_CellsToBeSubdivided.clear();
 
   // 4. Copy all the cell that does not insert a new point.
@@ -126,9 +126,10 @@ SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::G
       if (!this->m_EdgesPointIdentifier->IndexExists(edge))
       {
         // No added new point in this triangle cell
-        output->AddFaceTriangle(static_cast<OutputPointIdentifier>(cellPointIdArray[0]),
-                                static_cast<OutputPointIdentifier>(cellPointIdArray[1]),
-                                static_cast<OutputPointIdentifier>(cellPointIdArray[2]));
+        const auto qeprimal = output->AddFaceTriangle(static_cast<OutputPointIdentifier>(cellPointIdArray[0]),
+                                                      static_cast<OutputPointIdentifier>(cellPointIdArray[1]),
+                                                      static_cast<OutputPointIdentifier>(cellPointIdArray[2]));
+        this->PassCellData(cellIt.Index(), qeprimal);
         break;
       }
       else if (this->m_EdgesPointIdentifier->ElementAt(edge) != NumericTraits<OutputPointIdentifier>::max())
@@ -144,12 +145,14 @@ SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::G
           // There is no neighbor triangle cell or no splitting of the neighbor triangle cell.
           if (this->m_Uniform)
           {
-            output->AddFaceTriangle(pointIdArray[0][0], pointIdArray[0][1], pointIdArray[1][0]);
+            const auto qeprimal = output->AddFaceTriangle(pointIdArray[0][0], pointIdArray[0][1], pointIdArray[1][0]);
+            this->PassCellData(cellIt.Index(), qeprimal);
           }
           else
           {
             OutputQEType * newTriangleEdge =
               output->AddFaceTriangle(pointIdArray[0][0], pointIdArray[0][1], pointIdArray[1][0]);
+            this->PassCellData(cellIt.Index(), newTriangleEdge);
             this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
           }
         }
@@ -159,16 +162,20 @@ SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::G
           pointIdArray[1][1] = this->m_EdgesPointIdentifier->ElementAt(edge->GetSym());
           if (this->m_Uniform)
           {
-            output->AddFaceTriangle(pointIdArray[1][0], pointIdArray[1][1], pointIdArray[0][1]);
-            output->AddFaceTriangle(pointIdArray[1][1], pointIdArray[1][0], pointIdArray[0][0]);
+            const auto qeprimal0 = output->AddFaceTriangle(pointIdArray[1][0], pointIdArray[1][1], pointIdArray[0][1]);
+            this->PassCellData(cellIt.Index(), qeprimal0);
+            const auto qeprimal1 = output->AddFaceTriangle(pointIdArray[1][1], pointIdArray[1][0], pointIdArray[0][0]);
+            this->PassCellData(cellIt.Index(), qeprimal1);
           }
           else
           {
             OutputQEType * newTriangleEdge =
               output->AddFaceTriangle(pointIdArray[1][0], pointIdArray[1][1], pointIdArray[0][1]);
+            this->PassCellData(cellIt.Index(), newTriangleEdge);
             this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
 
             newTriangleEdge = output->AddFaceTriangle(pointIdArray[1][1], pointIdArray[1][0], pointIdArray[0][0]);
+            this->PassCellData(cellIt.Index(), newTriangleEdge);
             this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
           }
           this->m_EdgesPointIdentifier->SetElement(edge->GetSym(), NumericTraits<OutputPointIdentifier>::max());

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -110,16 +110,22 @@ protected:
   SplitTriangleFromOneEdge(OutputMeshType *              output,
                            const OutputPointIdentifier * trianglePointIds,
                            const OutputPointIdentifier * edgePointIds,
-                           const unsigned int *          splitEdges);
+                           const unsigned int *          splitEdges,
+                           const InputCellIdentifier     id);
   void
   SplitTriangleFromTwoEdges(OutputMeshType *              output,
                             const OutputPointIdentifier * trianglePointIds,
                             const OutputPointIdentifier * edgePointIds,
-                            const unsigned int *          splitEdges);
+                            const unsigned int *          splitEdges,
+                            const InputCellIdentifier     id);
   void
   SplitTriangleFromThreeEdges(OutputMeshType *              output,
                               const OutputPointIdentifier * trianglePointIds,
-                              const OutputPointIdentifier * edgePointIds);
+                              const OutputPointIdentifier * edgePointIds,
+                              const InputCellIdentifier     id);
+
+  void
+  PassCellData(const InputCellIdentifier inputId, const OutputQEType * outputEdge);
 
   void
   PrintSelf(std::ostream & os, Indent indent) const override;

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -140,20 +140,21 @@ TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::GenerateOutp
     if (n == 0)
     {
       // this face has no subdivided face as neighbor, copy it
-      output->AddFaceTriangle(trianglePointIds[0], trianglePointIds[1], trianglePointIds[2]);
+      const auto qeprimal = output->AddFaceTriangle(trianglePointIds[0], trianglePointIds[1], trianglePointIds[2]);
+      this->PassCellData(cellIt.Index(), qeprimal);
     }
     else if (n == 1)
     {
-      SplitTriangleFromOneEdge(output, trianglePointIds, edgePointIds, splitEdges);
+      SplitTriangleFromOneEdge(output, trianglePointIds, edgePointIds, splitEdges, cellIt.Index());
     }
     else if (n == 2)
     {
-      SplitTriangleFromTwoEdges(output, trianglePointIds, edgePointIds, splitEdges);
+      SplitTriangleFromTwoEdges(output, trianglePointIds, edgePointIds, splitEdges, cellIt.Index());
     }
     else if (n == 3)
     {
       // this face was not supposed to be subdivided but all neighbors are
-      SplitTriangleFromThreeEdges(output, trianglePointIds, edgePointIds);
+      SplitTriangleFromThreeEdges(output, trianglePointIds, edgePointIds, cellIt.Index());
     }
 
     ++cellIt;
@@ -166,14 +167,17 @@ TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::SplitTriangl
   OutputMeshType *              output,
   const OutputPointIdentifier * trianglePointIds,
   const OutputPointIdentifier * edgePointIds,
-  const unsigned int *          splitEdges)
+  const unsigned int *          splitEdges,
+  const InputCellIdentifier     id)
 {
   unsigned int ii = splitEdges[0];
   unsigned int jj = (ii + 1) % 3;
   unsigned int kk = (ii + 2) % 3;
 
-  output->AddFaceTriangle(edgePointIds[ii], trianglePointIds[jj], trianglePointIds[kk]);
-  output->AddFaceTriangle(edgePointIds[ii], trianglePointIds[kk], trianglePointIds[ii]);
+  const auto qeprimal0 = output->AddFaceTriangle(edgePointIds[ii], trianglePointIds[jj], trianglePointIds[kk]);
+  this->PassCellData(id, qeprimal0);
+  const auto qeprimal1 = output->AddFaceTriangle(edgePointIds[ii], trianglePointIds[kk], trianglePointIds[ii]);
+  this->PassCellData(id, qeprimal1);
 }
 
 template <typename TInputMesh, typename TOutputMesh>
@@ -182,7 +186,8 @@ TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::SplitTriangl
   OutputMeshType *              output,
   const OutputPointIdentifier * trianglePointIds,
   const OutputPointIdentifier * edgePointIds,
-  const unsigned int *          splitEdges)
+  const unsigned int *          splitEdges,
+  const InputCellIdentifier     id)
 {
   unsigned int ii = splitEdges[0];
   unsigned int jj = splitEdges[1];
@@ -190,23 +195,32 @@ TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::SplitTriangl
   if (ii == 0 && jj == 1)
   {
     // ii = 0, jj = 1
-    output->AddFaceTriangle(trianglePointIds[2], trianglePointIds[0], edgePointIds[0]);
-    output->AddFaceTriangle(trianglePointIds[2], edgePointIds[0], edgePointIds[1]);
-    output->AddFaceTriangle(edgePointIds[0], trianglePointIds[1], edgePointIds[1]);
+    const auto qeprimal0 = output->AddFaceTriangle(trianglePointIds[2], trianglePointIds[0], edgePointIds[0]);
+    this->PassCellData(id, qeprimal0);
+    const auto qeprimal1 = output->AddFaceTriangle(trianglePointIds[2], edgePointIds[0], edgePointIds[1]);
+    this->PassCellData(id, qeprimal1);
+    const auto qeprimal2 = output->AddFaceTriangle(edgePointIds[0], trianglePointIds[1], edgePointIds[1]);
+    this->PassCellData(id, qeprimal2);
   }
   else if (ii == 0 && jj == 2)
   {
     // ii = 0, jj = 2
-    output->AddFaceTriangle(trianglePointIds[1], trianglePointIds[2], edgePointIds[0]);
-    output->AddFaceTriangle(trianglePointIds[2], edgePointIds[2], edgePointIds[0]);
-    output->AddFaceTriangle(edgePointIds[2], trianglePointIds[0], edgePointIds[0]);
+    const auto qeprimal0 = output->AddFaceTriangle(trianglePointIds[1], trianglePointIds[2], edgePointIds[0]);
+    this->PassCellData(id, qeprimal0);
+    const auto qeprimal1 = output->AddFaceTriangle(trianglePointIds[2], edgePointIds[2], edgePointIds[0]);
+    this->PassCellData(id, qeprimal1);
+    const auto qeprimal2 = output->AddFaceTriangle(edgePointIds[2], trianglePointIds[0], edgePointIds[0]);
+    this->PassCellData(id, qeprimal2);
   }
   else if (ii == 1 && jj == 2)
   {
     // ii = 1, jj = 2
-    output->AddFaceTriangle(trianglePointIds[0], trianglePointIds[1], edgePointIds[1]);
-    output->AddFaceTriangle(trianglePointIds[0], edgePointIds[1], edgePointIds[2]);
-    output->AddFaceTriangle(edgePointIds[1], trianglePointIds[2], edgePointIds[2]);
+    const auto qeprimal0 = output->AddFaceTriangle(trianglePointIds[0], trianglePointIds[1], edgePointIds[1]);
+    this->PassCellData(id, qeprimal0);
+    const auto qeprimal1 = output->AddFaceTriangle(trianglePointIds[0], edgePointIds[1], edgePointIds[2]);
+    this->PassCellData(id, qeprimal1);
+    const auto qeprimal2 = output->AddFaceTriangle(edgePointIds[1], trianglePointIds[2], edgePointIds[2]);
+    this->PassCellData(id, qeprimal2);
   }
 }
 
@@ -215,30 +229,60 @@ void
 TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::SplitTriangleFromThreeEdges(
   OutputMeshType *              output,
   const OutputPointIdentifier * trianglePointIds,
-  const OutputPointIdentifier * edgePointIds)
+  const OutputPointIdentifier * edgePointIds,
+  const InputCellIdentifier     id)
 {
   // this face was not supposed to be subdivided but all neighbors are
   if (this->m_Uniform)
   {
-    output->AddFaceTriangle(trianglePointIds[0], edgePointIds[0], edgePointIds[2]);
-    output->AddFaceTriangle(edgePointIds[0], trianglePointIds[1], edgePointIds[1]);
-    output->AddFaceTriangle(edgePointIds[1], trianglePointIds[2], edgePointIds[2]);
-    output->AddFaceTriangle(edgePointIds[0], edgePointIds[1], edgePointIds[2]);
+    const auto qeprimal0 = output->AddFaceTriangle(trianglePointIds[0], edgePointIds[0], edgePointIds[2]);
+    this->PassCellData(id, qeprimal0);
+    const auto qeprimal1 = output->AddFaceTriangle(edgePointIds[0], trianglePointIds[1], edgePointIds[1]);
+    this->PassCellData(id, qeprimal1);
+    const auto qeprimal2 = output->AddFaceTriangle(edgePointIds[1], trianglePointIds[2], edgePointIds[2]);
+    this->PassCellData(id, qeprimal2);
+    const auto qeprimal3 = output->AddFaceTriangle(edgePointIds[0], edgePointIds[1], edgePointIds[2]);
+    this->PassCellData(id, qeprimal3);
   }
   else
   {
     OutputQEType * newTriangleEdge = output->AddFaceTriangle(trianglePointIds[0], edgePointIds[0], edgePointIds[2]);
+    this->PassCellData(id, newTriangleEdge);
     this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
 
     newTriangleEdge = output->AddFaceTriangle(edgePointIds[0], trianglePointIds[1], edgePointIds[1]);
+    this->PassCellData(id, newTriangleEdge);
     this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
 
     newTriangleEdge = output->AddFaceTriangle(edgePointIds[1], trianglePointIds[2], edgePointIds[2]);
+    this->PassCellData(id, newTriangleEdge);
     this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
 
     newTriangleEdge = output->AddFaceTriangle(edgePointIds[0], edgePointIds[1], edgePointIds[2]);
+    this->PassCellData(id, newTriangleEdge);
     this->m_CellsToBeSubdivided.push_back(newTriangleEdge->GetLeft());
   }
+}
+
+template <typename TInputMesh, typename TOutputMesh>
+void
+TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::PassCellData(const InputCellIdentifier inputId,
+                                                                                 const OutputQEType *      outputEdge)
+{
+  if (nullptr == outputEdge)
+  {
+    return;
+  }
+  if (nullptr == this->GetInput()->GetCellData())
+  {
+    return;
+  }
+  if (!this->GetInput()->GetCellData()->IndexExists(inputId))
+  {
+    return;
+  }
+  const auto data = this->GetInput()->GetCellData()->ElementAt(inputId);
+  this->GetOutput()->SetCellData(outputEdge->GetLeft(), data);
 }
 
 template <typename TInputMesh, typename TOutputMesh>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SubdivisionQuadEdgeMeshFilterTests
 itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
 itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
 itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest.cxx
 itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
 )
 
@@ -142,3 +143,7 @@ itk_add_test(NAME itkCriterionLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilterT
   COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
   itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
   DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_edge_loop.vtk 2 0.05)
+
+itk_add_test(NAME itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest
+  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
+  itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest)

--- a/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest.cxx
+++ b/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest.cxx
@@ -1,0 +1,150 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+// ITK
+#include <itkQuadEdgeMesh.h>
+#include <itkRegularSphereMeshSource.h>
+#include <itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h>
+#include <itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h>
+#include <itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h>
+#include <itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h>
+#include <itkTriangleHelper.h>
+#include <itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h>
+
+template <typename SubdivisionType>
+void
+SubdivisionTestHelper(const bool uniform)
+{
+
+  // Typedefs
+  const unsigned int Dimension = 3;
+  using TCoordinate = float;
+  using TQEMesh = itk::QuadEdgeMesh<TCoordinate, Dimension>;
+  using TSource = itk::RegularSphereMeshSource<TQEMesh>;
+  using TTriangleHelper = itk::TriangleHelper<typename TQEMesh::PointType>;
+  using TSubdivision = SubdivisionType;
+  using TSubdivisionIt = itk::IterativeTriangleCellSubdivisionQuadEdgeMeshFilter<TQEMesh, TSubdivision>;
+
+  // Generate some input mesh data
+  const auto sphere = TSource::New();
+  sphere->Update();
+
+  const auto i_mesh = TQEMesh::New();
+  i_mesh->Graft(sphere->GetOutput());
+  i_mesh->DisconnectPipeline();
+
+  typename TSubdivisionIt::SubdivisionCellContainer cells_to_subdivide;
+
+  // Assign cell data (different for each octant).
+  for (auto it = i_mesh->GetCells()->Begin(); it != i_mesh->GetCells()->End(); ++it)
+  {
+    const auto cell = it.Value();
+
+    const auto centroid = TTriangleHelper::ComputeGravityCenter(i_mesh->GetPoint(cell->GetPointIds()[0]),
+                                                                i_mesh->GetPoint(cell->GetPointIds()[1]),
+                                                                i_mesh->GetPoint(cell->GetPointIds()[2]));
+
+    unsigned int data = 0;
+    if (centroid[0] < 0 && centroid[1] < 0 && centroid[2] < 0)
+    {
+      data = 1;
+    }
+    else if (centroid[0] < 0 && centroid[1] < 0 && centroid[2] >= 0)
+    {
+      data = 2;
+    }
+    else if (centroid[0] < 0 && centroid[1] >= 0 && centroid[2] < 0)
+    {
+      data = 3;
+    }
+    else if (centroid[0] < 0 && centroid[1] >= 0 && centroid[2] >= 0)
+    {
+      data = 4;
+      cells_to_subdivide.push_back(it.Index());
+    }
+    else if (centroid[0] >= 0 && centroid[1] < 0 && centroid[2] < 0)
+    {
+      data = 5;
+    }
+    else if (centroid[0] >= 0 && centroid[1] < 0 && centroid[2] >= 0)
+    {
+      data = 6;
+    }
+    else if (centroid[0] >= 0 && centroid[1] >= 0 && centroid[2] < 0)
+    {
+      data = 7;
+    }
+    else if (centroid[0] >= 0 && centroid[1] >= 0 && centroid[2] >= 0)
+    {
+      data = 8;
+    }
+
+    i_mesh->SetCellData(it.Index(), data);
+  }
+
+  // Assert one CellData entry for each Cell
+  const auto i_cell = i_mesh->GetNumberOfCells();
+  const auto i_data = i_mesh->GetCellData()->Size();
+  itkAssertOrThrowMacro(i_cell == i_data, "Incorrect number of entries in input cell data array.");
+
+  const size_t resolution = 3;
+
+  const auto subdivide = TSubdivisionIt::New();
+  subdivide->SetResolutionLevels(resolution);
+  if (!uniform)
+  {
+    subdivide->SetCellsToBeSubdivided(cells_to_subdivide);
+  }
+  subdivide->SetInput(i_mesh);
+  subdivide->Update();
+
+  const auto o_mesh = TQEMesh::New();
+  o_mesh->Graft(subdivide->GetOutput());
+  o_mesh->DisconnectPipeline();
+
+  // Assert one CellData entry for each Cell
+  const auto o_cell = o_mesh->GetNumberOfCells();
+  const auto o_data = o_mesh->GetCellData()->Size();
+  itkAssertOrThrowMacro(o_cell == o_data, "Incorrect number of entries in output cell data array.");
+}
+
+int
+itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest(int, char *[])
+{
+
+  const unsigned int Dimension = 3;
+  using TCoordinate = float;
+  using TQEMesh = itk::QuadEdgeMesh<TCoordinate, Dimension>;
+
+  using TButterfly = itk::ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter<TQEMesh, TQEMesh>;
+  using TLinear = itk::LinearTriangleCellSubdivisionQuadEdgeMeshFilter<TQEMesh, TQEMesh>;
+  using TLoop = itk::LoopTriangleCellSubdivisionQuadEdgeMeshFilter<TQEMesh, TQEMesh>;
+  using TSquare = itk::SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter<TQEMesh, TQEMesh>;
+
+  SubdivisionTestHelper<TButterfly>(true);
+  SubdivisionTestHelper<TLinear>(true);
+  SubdivisionTestHelper<TLoop>(true);
+  SubdivisionTestHelper<TSquare>(true);
+
+  SubdivisionTestHelper<TButterfly>(false);
+  SubdivisionTestHelper<TLinear>(false);
+  SubdivisionTestHelper<TLoop>(false);
+  SubdivisionTestHelper<TSquare>(false);
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Currently, any CellData in the input mesh is not passed to the
subdivided output mesh.  This patch checks if any CellData exists,
and if so, passes that data into the child cells of the subdivided
output mesh.  This patch creates a new method, PassCellData, which
is called immediately following each call to AddFaceTriangle.  Moreover,
the interfaces to SplitTriangleFromOneEdge, SplitTriangleFromTwoEdges,
and SplitTriangleFromThreeEdges have all been extended to take the
cell identifier of the input cell, so that it will be available to pass to
the PassCellData method.  This has also required that the class for
iterative subdivision (IterativeCellSubdivisionQuadEdgeMeshFilter) be
updated.