### PR TITLE
ENH: Add Minimal Tests for Wrapped Classes

### DIFF
--- a/wrapping/test/CMakeLists.txt
+++ b/wrapping/test/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(SUBDIVISION_CLASSES
+  CellAreaTriangleCellSubdivisionCriterion
+  ConditionalSubdivisionQuadEdgeMeshFilter
+  EdgeLengthTriangleEdgeCellSubdivisionCriterion
+  IterativeTriangleCellSubdivisionQuadEdgeMeshFilter
+  LinearTriangleCellSubdivisionQuadEdgeMeshFilter
+  LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter
+  LoopTriangleCellSubdivisionQuadEdgeMeshFilter
+  LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter
+  ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter
+  ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter
+  SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter
+  TriangleCellSubdivisionQuadEdgeMeshFilter
+  TriangleEdgeCellSubdivisionQuadEdgeMeshFilter)
+
+foreach(s ${SUBDIVISION_CLASSES})
+
+  itk_python_expression_add_test(NAME itk${s}Test
+   EXPRESSION "instance = itk.${s}.New()")
+
+endforeach()


### PR DESCRIPTION
This patch supplies a minimal test suite, demonstrating that
each of the wrapped classes may be instantiated in python
without error.  This suite tests only instantiation, and
in the future should be expanded or replaced by more rigorous
tests of functionality.