### PR TITLE
ENH: Improve Testing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,136 +13,52 @@ CreateTestDriver(SubdivisionQuadEdgeMeshFilter  "${SubdivisionQuadEdgeMeshFilter
 set(INPUTDATA ${CMAKE_CURRENT_SOURCE_DIR}/data)
 set(TEMP ${ITK_TEST_OUTPUT_DIR})
 
-itk_add_test(NAME itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_butterfly_0.vtk 0 1)
+# Test TriangleCellSubdivision Filters
 
-itk_add_test(NAME itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_butterfly_1.vtk 0 2)
+foreach(METHOD 0 1 2 3)
 
-itk_add_test(NAME itkLinearTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_linear_0.vtk 1 1)
+  itk_add_test(NAME itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest${METHOD}
+    COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
+    itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest
+    DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_${METHOD}.vtk ${METHOD} 0.01)
 
-itk_add_test(NAME itkLinearTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_linear_1.vtk 1 2)
+  foreach(RESOLUTION 1 2)
 
-itk_add_test(NAME itkLoopTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_loop_0.vtk 2 1)
+    itk_add_test(NAME itkAdaptiveTriangleCellSubdivisionQuadEdgeMeshFilterTest${METHOD}${RESOLUTION}
+      COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
+      itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
+      DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_${METHOD}${RESOLUTION}.vtk ${METHOD} ${RESOLUTION})
 
-itk_add_test(NAME itkLoopTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_loop_1.vtk 2 2)
+    foreach(ADAPTIVE 0 1)
 
+      itk_add_test(NAME itkAdaptiveTriangleCellSubdivisionQuadEdgeMeshFilterTest${METHOD}${RESOLUTION}${ADAPTIVE}
+        COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
+        itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
+        DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_${METHOD}${RESOLUTION}${ADAPTIVE}.vtk ${METHOD} ${RESOLUTION} ${ADAPTIVE})
 
-itk_add_test(NAME itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_square3_0.vtk 3 1)
+    endforeach()
 
-itk_add_test(NAME itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_square3_1.vtk 3 2)
+  endforeach()
 
-itk_add_test(NAME itkAdaptiveModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_butterfly_0.vtk 0 1 1)
+endforeach()
 
-itk_add_test(NAME itkAdaptiveModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_butterfly_1.vtk 0 2 1)
+# Test TriangleEdgeCellSubdivision Filters
 
-itk_add_test(NAME itkAdaptiveLinearTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_linear_0.vtk 1 1 1)
+foreach(METHOD 0 1 2)
 
-itk_add_test(NAME itkAdaptiveLinearTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_linear_1.vtk 1 2 1)
+  itk_add_test(NAME itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest${METHOD}
+    COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
+    itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
+    DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_edge_${METHOD}.vtk ${METHOD} 0.1)
 
-itk_add_test(NAME itkAdaptiveLoopTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_loop_0.vtk 2 1 1)
+  itk_add_test(NAME itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest${METHOD}
+    COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
+    itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
+    DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_edge_${METHOD}.vtk ${METHOD} 0.05)
 
-itk_add_test(NAME itkAdaptiveLoopTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_loop_1.vtk 2 2 1)
+endforeach()
 
-itk_add_test(NAME itkAdaptiveSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilterTest0
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_square3_0.vtk 3 1 1)
-
-itk_add_test(NAME itkAdaptiveSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilterTest1
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_adaptive_square_1.vtk 3 2 1)
-
-itk_add_test(NAME itkCriterionButterflyTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_butterfly.vtk 0 0.01)
-
-itk_add_test(NAME itkCriterionLinearTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_linear.vtk 1 0.01)
-
-itk_add_test(NAME itkCriterionLoopTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_loop.vtk 2 0.01)
-
-itk_add_test(NAME itkCriterionSquareTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_square3.vtk 3 0.01)
-
-itk_add_test(NAME itkButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_edge_butterfly.vtk 0 0.1)
-
-itk_add_test(NAME itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_edge_linear.vtk 1 0.1)
-
-itk_add_test(NAME itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_edge_loop.vtk 2 0.01)
-
-itk_add_test(NAME itkCriterionButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_edge_butterfly.vtk 0 0.05)
-
-itk_add_test(NAME itkCriterionLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_edge_linear.vtk 1 0.05)
-
-itk_add_test(NAME itkCriterionLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  COMMAND SubdivisionQuadEdgeMeshFilterTestDriver
-  itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest
-  DATA{${INPUTDATA}/venus.vtk} ${TEMP}/venus_criterion_edge_loop.vtk 2 0.05)
+# Test whether CellData is properly passed
 
 itk_add_test(NAME itkTriangleCellSubdivisionQuadEdgeMeshFilterCellDataTest
   COMMAND SubdivisionQuadEdgeMeshFilterTestDriver

--- a/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -74,6 +74,8 @@ TriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
       cellsToBeSubdivided.push_back(9);
 
       subdivision->SetCellsToBeSubdivided(cellsToBeSubdivided);
+
+      ITK_TEST_EXPECT_EQUAL(7, subdivision->GetCellsToBeSubdivided().size());
     }
     else
     {
@@ -84,6 +86,8 @@ TriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
       subdivision->AddSubdividedCellId(5);
       subdivision->AddSubdividedCellId(6);
       subdivision->AddSubdividedCellId(9);
+
+      ITK_TEST_EXPECT_EQUAL(7, subdivision->GetCellsToBeSubdivided().size());
     }
   }
 
@@ -129,15 +133,22 @@ TriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 int
 itkTriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
-  if (argc < 3)
+  if (argc < 4)
   {
-    std::cerr << "Missing Parameters " << std::endl;
-    std::cerr << "Usage: " << argv[0];
-    std::cerr << " inputMeshFile  outputMeshFile subdivisionType Resolution non-uniform" << std::endl;
-    std::cerr << " 0 : ModifiedButterfly " << std::endl;
-    std::cerr << " 1 : Linear " << std::endl;
-    std::cerr << " 2 : Loop " << std::endl;
-    std::cerr << " 3 : Squarethree " << std::endl;
+    std::cerr << "Error: Missing Parameters!" << std::endl;
+    std::cerr << "Usage: " << argv[0] << '\n';
+    std::cerr << "  inputMeshFile\n";
+    std::cerr << "  outputMeshFile\n";
+    std::cerr << "  subdivisionType\n";
+    std::cerr << "    0 : ModifiedButterfly\n";
+    std::cerr << "    1 : Linear\n";
+    std::cerr << "    2 : Loop\n";
+    std::cerr << "    3 : SquareThree\n";
+    std::cerr << "  [Resolution]\n";
+    std::cerr << "  [Adaptive]\n";
+    std::cerr << "    0 : AddSubdividedCellId\n";
+    std::cerr << "    1 : SetCellsToBeSubdivided\n";
+    std::cerr << std::flush;
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
1. Test an untested branch of itkTriangleCellSubdivisionQuadEdgeMeshFilterTest
   so as to exercise AddSubdividedCellId().
2. Add assertions to check the functionality of SetCellsToBeSubdivided()
   and AddSubdividedCellId().
3. Reduce redundancy in the CMakeLists.txt file for the testing suite by
   using foreach loops as appropriate.
4. Minimal improvement in testing coverage.
     Line coverage: 88.9% => 89.6%
     Function coverage: 81.2% => 84.0%