### PR TITLE
COMP: Address Wunused-local-typedefs and Waddress

### DIFF
--- a/test/itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -34,13 +34,11 @@ CriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
 
   using TriangleCellSubdivisionFilterType = TTriangleCellSubdivisionFilter;
-  using TriangleCellSubdivisionFilterPointer = typename TTriangleCellSubdivisionFilter::Pointer;
   using InputMeshType = typename TriangleCellSubdivisionFilterType::InputMeshType;
   using OutputMeshType = typename TriangleCellSubdivisionFilterType::OutputMeshType;
 
   using CriterionType =
     itk::CellAreaTriangleCellSubdivisionCriterion<typename TriangleCellSubdivisionFilterType::SubdivisionFilterType>;
-  using CriterionPointer = typename CriterionType::Pointer;
   using ReaderType = itk::MeshFileReader<InputMeshType>;
   using WriterType = itk::MeshFileWriter<OutputMeshType>;
 
@@ -50,7 +48,7 @@ CriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 
   const auto subdivision = TriangleCellSubdivisionFilterType::New();
   const auto criterion = CriterionType::New();
-  ITK_TEST_EXPECT_EQUAL(criterion->GetNameOfClass(), "CellAreaTriangleCellSubdivisionCriterion");
+  ITK_TEST_EXPECT_EQUAL(criterion->GetNameOfClass(), std::string("CellAreaTriangleCellSubdivisionCriterion"));
   criterion->SetMaximumArea(1.0);
   ITK_TEST_SET_GET_VALUE(1.0, criterion->GetMaximumArea());
   if (argc >= 5)

--- a/test/itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -33,13 +33,11 @@ CriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv
 {
 
   using TriangleEdgeCellSubdivisionFilterType = TTriangleEdgeCellSubdivisionFilter;
-  using TriangleEdgeCellSubdivisionFilterPointer = typename TriangleEdgeCellSubdivisionFilterType::Pointer;
   using InputMeshType = typename TriangleEdgeCellSubdivisionFilterType::InputMeshType;
   using OutputMeshType = typename TriangleEdgeCellSubdivisionFilterType::OutputMeshType;
 
   using CriterionType = itk::EdgeLengthTriangleEdgeCellSubdivisionCriterion<
     typename TriangleEdgeCellSubdivisionFilterType::SubdivisionFilterType>;
-  using CriterionPointer = typename CriterionType::Pointer;
   using ReaderType = itk::MeshFileReader<InputMeshType>;
   using WriterType = itk::MeshFileWriter<OutputMeshType>;
 
@@ -49,7 +47,7 @@ CriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv
 
   const auto subdivision = TriangleEdgeCellSubdivisionFilterType::New();
   const auto criterion = CriterionType::New();
-  ITK_TEST_EXPECT_EQUAL(criterion->GetNameOfClass(), "EdgeLengthTriangleEdgeCellSubdivisionCriterion");
+  ITK_TEST_EXPECT_EQUAL(criterion->GetNameOfClass(), std::string("EdgeLengthTriangleEdgeCellSubdivisionCriterion"));
   criterion->SetMaximumLength(1.0);
   ITK_TEST_SET_GET_VALUE(1.0, criterion->GetMaximumLength());
   if (argc >= 5)

--- a/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -48,7 +48,8 @@ TriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
   ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   const auto subdivision = IterativeTriangleCellSubdivisionFilterType::New();
-  ITK_TEST_EXPECT_EQUAL(subdivision->GetNameOfClass(), "IterativeTriangleCellSubdivisionQuadEdgeMeshFilter");
+  ITK_TEST_EXPECT_EQUAL(subdivision->GetNameOfClass(),
+                        std::string("IterativeTriangleCellSubdivisionQuadEdgeMeshFilter"));
   subdivision->Print(std::cout);
 
   if (argc >= 5)

--- a/test/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -32,7 +32,6 @@ TriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
 
   using TriangleEdgeCellSubdivisionFilterType = TTriangleEdgeCellSubdivisionFilter;
-  using TriangleEdgeCellSubdivisionFilterPointer = typename TriangleEdgeCellSubdivisionFilterType::Pointer;
   using InputMeshType = typename TriangleEdgeCellSubdivisionFilterType::InputMeshType;
   using OutputMeshType = typename TriangleEdgeCellSubdivisionFilterType::OutputMeshType;
   using SubdivisionCellContainer = typename TriangleEdgeCellSubdivisionFilterType::SubdivisionCellContainer;


### PR DESCRIPTION
This patch addresses warnings due to:

1. Unused local typedefs.
2. Comparison of strings with string literals.

Warnings were emitted on g++ 9.3.0 when compiling with
Wall, Wextra, Wmissing-braces.