### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
@@ -36,7 +36,7 @@ class ConditionalSubdivisionQuadEdgeMeshFilter
   : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, typename TSubdivisionFilter::OutputMeshType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConditionalSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ConditionalSubdivisionQuadEdgeMeshFilter);
 
   using Self = ConditionalSubdivisionQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, typename TSubdivisionFilter::OutputMeshType>;

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -36,7 +36,7 @@ class IterativeTriangleCellSubdivisionQuadEdgeMeshFilter
   : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, typename TCellSubdivisionFilter::OutputMeshType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = IterativeTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, typename TCellSubdivisionFilter::OutputMeshType>;

--- a/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -37,7 +37,7 @@ class LinearTriangleCellSubdivisionQuadEdgeMeshFilter
   : public TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = LinearTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,7 +34,7 @@ class LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter
   : public TriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -55,7 +55,7 @@ class LoopTriangleCellSubdivisionQuadEdgeMeshFilter
   : public TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = LoopTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,7 +34,7 @@ class LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter
   : public TriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -38,7 +38,7 @@ class ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter
   : public TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,7 +34,7 @@ class ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter
   : public TriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = ModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,7 +34,7 @@ class SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter
   : public TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSubdivisionQuadEdgeMeshFilter.h
@@ -40,7 +40,7 @@ template <typename TInputMesh, typename TOutputMesh = TInputMesh>
 class SubdivisionQuadEdgeMeshFilter : public QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(SubdivisionQuadEdgeMeshFilter);
 
   using Self = SubdivisionQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -39,7 +39,7 @@ template <typename TInputMesh, typename TOutputMesh = TInputMesh>
 class TriangleCellSubdivisionQuadEdgeMeshFilter : public SubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(TriangleCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = TriangleCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = SubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;

--- a/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -34,7 +34,7 @@ class TriangleEdgeCellSubdivisionQuadEdgeMeshFilter
   : public TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   using Self = TriangleEdgeCellSubdivisionQuadEdgeMeshFilter;
   using Superclass = TriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.