### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkCellAreaTriangleCellSubdivisionCriterion.hxx
+++ b/include/itkCellAreaTriangleCellSubdivisionCriterion.hxx
@@ -19,7 +19,6 @@
 #ifndef itkCellAreaTriangleCellSubdivisionCriterion_hxx
 #define itkCellAreaTriangleCellSubdivisionCriterion_hxx
 
-#include "itkCellAreaTriangleCellSubdivisionCriterion.h"
 
 namespace itk
 {

--- a/include/itkConditionalSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkConditionalSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkConditionalSubdivisionQuadEdgeMeshFilter_hxx
 #define itkConditionalSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkConditionalSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.hxx
+++ b/include/itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.hxx
@@ -19,7 +19,6 @@
 #ifndef itkEdgeLengthTriangleEdgeCellSubdivisionCriterion_hxx
 #define itkEdgeLengthTriangleEdgeCellSubdivisionCriterion_hxx
 
-#include "itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.h"
 
 namespace itk
 {

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h"
 #include <algorithm>
 
 namespace itk

--- a/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h"
 #include "itkMath.h"
 #include <set>
 

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h"
 #include "itkMath.h"
 #include <algorithm>
 

--- a/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h"
 #include "itkNumericTraits.h"
 
 namespace itk

--- a/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkModifiedButterflyTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkSubdivisionQuadEdgeMeshFilter_hxx
 #define itkSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkTriangleCellSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {

--- a/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 #define itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter_hxx
 
-#include "itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h"
 
 namespace itk
 {


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

