### PR TITLE
COMP: Modules need updated version of ITK

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx.orig
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.hxx.orig
@@ -1,0 +1,88 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
+#define itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter_hxx
+
+<<<<<<< HEAD
+#include "itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h"
+#include <algorithm>
+=======
+>>>>>>> COMP: Remove inclusion of .hxx files as headers
+
+namespace itk
+{
+template <typename TInputMesh, typename TCellSubdivisionFilter>
+IterativeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TCellSubdivisionFilter>::
+  IterativeTriangleCellSubdivisionQuadEdgeMeshFilter()
+{
+  this->m_ResolutionLevels = 1;
+}
+
+template <typename TInputMesh, typename TCellSubdivisionFilter>
+void
+IterativeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TCellSubdivisionFilter>::SetCellsToBeSubdivided(
+  const SubdivisionCellContainer & cellIdList)
+{
+  this->m_CellsToBeSubdivided = cellIdList;
+  this->Modified();
+}
+
+template <typename TInputMesh, typename TCellSubdivisionFilter>
+void
+IterativeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TCellSubdivisionFilter>::AddSubdividedCellId(
+  OutputCellIdentifier cellId)
+{
+  this->m_CellsToBeSubdivided.push_back(cellId);
+  this->Modified();
+}
+
+template <typename TInputMesh, typename TCellSubdivisionFilter>
+void
+IterativeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TCellSubdivisionFilter>::GenerateData()
+{
+  this->m_CellSubdivisionFilterVector.clear();
+  const auto resolution = std::max(static_cast<unsigned int>(1), this->m_ResolutionLevels);
+  for (size_t i = 0; i < resolution; ++i)
+  {
+    this->m_CellSubdivisionFilterVector.push_back(TCellSubdivisionFilter::New());
+  }
+  this->m_CellSubdivisionFilterVector.at(0)->SetInput(this->GetInput());
+  this->m_CellSubdivisionFilterVector.at(0)->SetCellsToBeSubdivided(this->m_CellsToBeSubdivided);
+  this->m_CellSubdivisionFilterVector.at(0)->Update();
+  this->GraftOutput(this->m_CellSubdivisionFilterVector.at(0)->GetOutput());
+  for (size_t i = 1; i < resolution; ++i)
+  {
+    this->m_CellSubdivisionFilterVector.at(i)->SetInput(this->GetOutput());
+    this->m_CellSubdivisionFilterVector.at(i)->SetCellsToBeSubdivided(
+      this->m_CellSubdivisionFilterVector.at(i - 1)->GetCellsToBeSubdivided());
+    this->m_CellSubdivisionFilterVector.at(i)->Update();
+    this->GraftOutput(this->m_CellSubdivisionFilterVector.at(i)->GetOutput());
+  }
+}
+
+template <typename TInputMesh, typename TCellSubdivisionFilter>
+void
+IterativeTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TCellSubdivisionFilter>::PrintSelf(std::ostream & os,
+                                                                                                  Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+  std::cout << indent << "Subdivision Resolution Levels: " << m_ResolutionLevels << std::endl;
+}
+} // namespace itk
+#endif


### PR DESCRIPTION
COMP: Modules need updated version of ITK

Removal of .h includes from same named .hxx files
requires removal of outdated rule that is no longer
relevant.

This PR will update the version of ITK that is
used for the remove modules."



BRANCH_NAME=update-reference-itk-version
for remdir_script in *.remote.cmake; do
   
  remdir="${remdir_script//*.remote.cmake/}"
  if [ ! -d "${remdir}" ] ;then
    echo "Missing directory ${remdir}"
    continue
  fi
  pushd "${remdir}" || exit
  echo "=============== $(pwd) ========="
  git checkout master
  git fetch origin
  git rebase origin/master
  git checkout -b ${BRANCH_NAME}
  sed 's/itk-git-tag : .*/itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"/g' $( fgrep -Rl "itk-git-tag:" |fgrep yml )

  git status
  diff_line_no=$(git diff |wc -l )
  if [ "${diff_line_no}" -ne 0 ]; then
    git add -p
    git commit -F /tmp/update_itk_msg

    gh pr create -a "@me" -F /tmp/update_itk_msg
  else
    echo "Skipping changes $(pwd)"
  fi
  git fetch
  git rebase origin/master 
  git push origin -f ${BRANCH_NAME}:${BRANCH_NAME}

  popd || exit
done
