### PR TITLE
COMP: Use modern macro for name of class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-## This config file is only relevant for clang-format version 8.0.0
+## This config file is only relevant for clang-format version 19.1.4
 ##
 ## Examples of each format style can be found on the in the clang-format documentation
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
@@ -10,142 +10,309 @@
 ## maintaining a consistent code style.
 ##
 ## EXAMPLE apply code style enforcement before commit:
-#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --modified
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --modified
 ## EXAMPLE apply code style enforcement after commit:
-#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --last
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --last
 ---
-# This configuration requires clang-format version 8.0.0 exactly.
-BasedOnStyle: Mozilla
+# This configuration requires clang-format version 19.1.4 exactly.
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Right
-AlignOperands:   true
-AlignTrailingComments: true
-# clang 9.0 AllowAllArgumentsOnNextLine: true
-# clang 9.0 AllowAllConstructorInitializersOnNextLine: true
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-# clang 9.0 AllowShortLambdasOnASingleLine: All
-# clang 9.0 features AllowShortIfStatementsOnASingleLine: Never
-AllowShortIfStatementsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: Inline Only merge functions defined inside a class. Implies empty.
+#AllowShortFunctionsOnASingleLine: None (in configuration: None) Never merge functions into a single line.
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBraces: Custom
+BitFieldColonSpacing: Both
 BraceWrapping:
-  # clang 9.0 feature AfterCaseLabel:  false
+  AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: true
+  AfterControlStatement: Always
   AfterEnum:       true
+  AfterExternBlock: true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
   BeforeCatch:     true
   BeforeElse:      true
-## This is the big change from historical ITK formatting!
-# Historically ITK used a style similar to https://en.wikipedia.org/wiki/Indentation_style#Whitesmiths_style
-# with indented braces, and not indented code.  This style is very difficult to automatically
-# maintain with code beautification tools.  Not indenting braces is more common among
-# formatting tools.
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-BreakBeforeBinaryOperators: None
-#clang 6.0 BreakBeforeInheritanceComma: true
-BreakInheritanceList: BeforeComma
-BreakBeforeTernaryOperators: true
-#clang 6.0 BreakConstructorInitializersBeforeComma: true
-BreakConstructorInitializers: BeforeComma
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: All
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeComma
 BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
 ## The following line allows larger lines in non-documentation code
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
 IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
 IndentPPDirectives: AfterHash
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
+MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 ## The following line allows larger lines in non-documentation code
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Middle
+PPIndentWidth:   -1
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
+ReferenceAlignment: Pointer
 ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
 # We may want to sort the includes as a separate pass
-SortIncludes:    false
+SortIncludes:    Never
+SortJavaStaticImport: Before
 # We may want to revisit this later
-SortUsingDeclarations: false
+SortUsingDeclarations: Never
 SpaceAfterCStyleCast: false
-# SpaceAfterLogicalNot: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles:  Never
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
+  - ITK_GCC_PRAGMA_PUSH
+  - ITK_GCC_PRAGMA_POP
+  - ITK_GCC_SUPPRESS_Wfloat_equal
+  - ITK_GCC_SUPPRESS_Wformat_nonliteral
+  - ITK_GCC_SUPPRESS_Warray_bounds
+  - ITK_CLANG_PRAGMA_PUSH
+  - ITK_CLANG_PRAGMA_POP
+  - ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+  - CLANG_PRAGMA_PUSH
+  - CLANG_PRAGMA_POP
+  - CLANG_SUPPRESS_Wfloat_equal
+  - INTEL_PRAGMA_WARN_PUSH
+  - INTEL_PRAGMA_WARN_POP
+  - INTEL_SUPPRESS_warning_1292
+  - itkTemplateFloatingToIntegerMacro
+  - itkLegacyMacro
+TableGenBreakInsideDAGArg: DontBreak
 TabWidth:        2
 UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
 ...

--- a/include/itkCellAreaTriangleCellSubdivisionCriterion.h
+++ b/include/itkCellAreaTriangleCellSubdivisionCriterion.h
@@ -61,7 +61,7 @@ public:
   using SubdivisionCellContainer = typename Superclass::SubdivisionCellContainer;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(CellAreaTriangleCellSubdivisionCriterion, QuadEdgeMeshTriangleCellSubdivisionCriterion);
+   itkOverrideGetNameOfClassMacro(CellAreaTriangleCellSubdivisionCriterion);
   itkNewMacro(Self);
 
   void

--- a/include/itkCellAreaTriangleCellSubdivisionCriterion.h
+++ b/include/itkCellAreaTriangleCellSubdivisionCriterion.h
@@ -61,7 +61,7 @@ public:
   using SubdivisionCellContainer = typename Superclass::SubdivisionCellContainer;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(CellAreaTriangleCellSubdivisionCriterion);
+  itkOverrideGetNameOfClassMacro(CellAreaTriangleCellSubdivisionCriterion);
   itkNewMacro(Self);
 
   void

--- a/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
@@ -58,7 +58,7 @@ public:
   using CriterionPointer = typename CriterionType::Pointer;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(ConditionalSubdivisionQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(ConditionalSubdivisionQuadEdgeMeshFilter);
   itkNewMacro(Self);
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkConditionalSubdivisionQuadEdgeMeshFilter.h
@@ -58,7 +58,7 @@ public:
   using CriterionPointer = typename CriterionType::Pointer;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(ConditionalSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(ConditionalSubdivisionQuadEdgeMeshFilter);
   itkNewMacro(Self);
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/include/itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.h
+++ b/include/itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.h
@@ -60,7 +60,7 @@ public:
   using SubdivisionCellContainer = typename Superclass::SubdivisionCellContainer;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(EdgeLengthTriangleEdgeCellSubdivisionCriterion);
+  itkOverrideGetNameOfClassMacro(EdgeLengthTriangleEdgeCellSubdivisionCriterion);
   itkNewMacro(Self);
 
   void

--- a/include/itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.h
+++ b/include/itkEdgeLengthTriangleEdgeCellSubdivisionCriterion.h
@@ -60,7 +60,7 @@ public:
   using SubdivisionCellContainer = typename Superclass::SubdivisionCellContainer;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(EdgeLengthTriangleEdgeCellSubdivisionCriterion, QuadEdgeMeshSubdivisionCriterion);
+   itkOverrideGetNameOfClassMacro(EdgeLengthTriangleEdgeCellSubdivisionCriterion);
   itkNewMacro(Self);
 
   void

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -59,7 +59,7 @@ public:
     typename CellSubdivisionFilterType::SubdivisionCellContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
   itkNewMacro(Self);
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkIterativeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -59,7 +59,7 @@ public:
     typename CellSubdivisionFilterType::SubdivisionCellContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(IterativeTriangleCellSubdivisionQuadEdgeMeshFilter);
   itkNewMacro(Self);
 
 #ifdef ITK_USE_CONCEPT_CHECKING

--- a/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -78,7 +78,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -78,7 +78,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(LinearTriangleCellSubdivisionQuadEdgeMeshFilter, TriangleCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(LinearTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -76,7 +76,7 @@ public:
   using OutputPointIdIterator = typename Superclass::OutputPointIdIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -76,7 +76,7 @@ public:
   using OutputPointIdIterator = typename Superclass::OutputPointIdIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter, TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(LinearTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -103,7 +103,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(LoopTriangleCellSubdivisionQuadEdgeMeshFilter, TriangleCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -103,7 +103,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(LoopTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -276,7 +276,6 @@ LoopTriangleCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::Smoothin
       opt[kk] = (1.0 - nn * beta) * ipt[kk] + beta * opt[kk];
     }
   }
-
   return opt;
 }
 } // namespace itk

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -76,7 +76,7 @@ public:
   using OutputPointIdIterator = typename Superclass::OutputPointIdIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter, TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -76,7 +76,7 @@ public:
   using OutputPointIdIterator = typename Superclass::OutputPointIdIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
+++ b/include/itkLoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.hxx
@@ -97,7 +97,6 @@ LoopTriangleEdgeCellSubdivisionQuadEdgeMeshFilter<TInputMesh, TOutputMesh>::AddN
   {
     itkExceptionMacro(<< "Wire edge detected");
   }
-
   return;
 }
 

--- a/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -79,7 +79,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter, TriangleCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -79,7 +79,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(ModifiedButterflyTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkQuadEdgeMeshSubdivisionCriterion.h
+++ b/include/itkQuadEdgeMeshSubdivisionCriterion.h
@@ -57,7 +57,7 @@ public:
   using SubdivisionCellContainer = typename TCellSubdivisionFilter::SubdivisionCellContainer;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(QuadEdgeMeshSubdivisionCriterion);
+  itkOverrideGetNameOfClassMacro(QuadEdgeMeshSubdivisionCriterion);
 
   virtual void
   Compute(MeshType * mesh, SubdivisionCellContainer & edgeList) = 0;

--- a/include/itkQuadEdgeMeshSubdivisionCriterion.h
+++ b/include/itkQuadEdgeMeshSubdivisionCriterion.h
@@ -57,7 +57,7 @@ public:
   using SubdivisionCellContainer = typename TCellSubdivisionFilter::SubdivisionCellContainer;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(QuadEdgeMeshSubdivisionCriterion, Object);
+   itkOverrideGetNameOfClassMacro(QuadEdgeMeshSubdivisionCriterion);
 
   virtual void
   Compute(MeshType * mesh, SubdivisionCellContainer & edgeList) = 0;

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -82,7 +82,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -82,7 +82,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename Superclass::EdgePointIdentifierContainerConstIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter, TriangleCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(SquareThreeTriangleCellSubdivisionQuadEdgeMeshFilter);
 
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);

--- a/include/itkSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSubdivisionQuadEdgeMeshFilter.h
@@ -90,7 +90,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename EdgePointIdentifierContainer::ConstIterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(SubdivisionQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(SubdivisionQuadEdgeMeshFilter);
 
 protected:
   SubdivisionQuadEdgeMeshFilter();

--- a/include/itkSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkSubdivisionQuadEdgeMeshFilter.h
@@ -90,7 +90,7 @@ public:
   using EdgePointIdentifierContainerConstIterator = typename EdgePointIdentifierContainer::ConstIterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(SubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(SubdivisionQuadEdgeMeshFilter);
 
 protected:
   SubdivisionQuadEdgeMeshFilter();

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -87,7 +87,7 @@ public:
   using SubdivisionCellContainerConstIterator = typename SubdivisionCellContainer::const_iterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(TriangleCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(TriangleCellSubdivisionQuadEdgeMeshFilter);
   itkGetConstReferenceMacro(CellsToBeSubdivided, SubdivisionCellContainer);
 
   void

--- a/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleCellSubdivisionQuadEdgeMeshFilter.h
@@ -87,7 +87,7 @@ public:
   using SubdivisionCellContainerConstIterator = typename SubdivisionCellContainer::const_iterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(TriangleCellSubdivisionQuadEdgeMeshFilter, SubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(TriangleCellSubdivisionQuadEdgeMeshFilter);
   itkGetConstReferenceMacro(CellsToBeSubdivided, SubdivisionCellContainer);
 
   void

--- a/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -82,7 +82,7 @@ public:
   using SubdivisionCellContainerConstIterator = typename SubdivisionCellContainer::const_iterator;
 
   /** Run-time type information (and related methods).   */
-  itkTypeMacro(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter, TriangleCellSubdivisionQuadEdgeMeshFilter);
+   itkOverrideGetNameOfClassMacro(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
   itkGetConstReferenceMacro(EdgesToBeSubdivided, SubdivisionCellContainer);
 
   void

--- a/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
+++ b/include/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilter.h
@@ -82,7 +82,7 @@ public:
   using SubdivisionCellContainerConstIterator = typename SubdivisionCellContainer::const_iterator;
 
   /** Run-time type information (and related methods).   */
-   itkOverrideGetNameOfClassMacro(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(TriangleEdgeCellSubdivisionQuadEdgeMeshFilter);
   itkGetConstReferenceMacro(EdgesToBeSubdivided, SubdivisionCellContainer);
 
   void

--- a/test/itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -178,6 +178,5 @@ itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[
     std::cerr << "You must have subdivision type " << std::endl;
     return EXIT_FAILURE;
   }
-
   return EXIT_SUCCESS;
 }

--- a/test/itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -166,6 +166,5 @@ itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * a
     std::cerr << "You must have subdivision type " << std::endl;
     return EXIT_FAILURE;
   }
-
   return EXIT_SUCCESS;
 }

--- a/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -210,6 +210,5 @@ itkTriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
     std::cerr << "You must have subdivision type " << std::endl;
     return EXIT_FAILURE;
   }
-
   return EXIT_SUCCESS;
 }

--- a/test/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/test/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -174,6 +174,5 @@ itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
     std::cerr << "You must have subdivision type " << std::endl;
     return EXIT_FAILURE;
   }
-
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When preparing for the future with ITK by setting
ITK_FUTURE_LEGACY_REMOVE:BOOL=ON
ITK_LEGACY_REMOVEBOOL=ON

The future preferred macro should be used
│ -  itkTypeMacro
│ +  itkOverrideGetNameOfClassMacro